### PR TITLE
Fixing some errors with database migration add-ons to Sentry and to the blog comments

### DIFF
--- a/app/database/migrations/2013_01_19_011903_create_posts_table.php
+++ b/app/database/migrations/2013_01_19_011903_create_posts_table.php
@@ -19,9 +19,9 @@ class CreatePostsTable extends Migration {
 			$table->string('title');
 			$table->string('slug');
 			$table->text('content');
-			$table->string('meta_title');
-			$table->string('meta_description');
-			$table->string('meta_keywords');
+			$table->string('meta_title')->nullable();
+			$table->string('meta_description')->nullable();
+			$table->string('meta_keywords')->nullable();
 			$table->timestamps();
 		});
 	}

--- a/app/database/migrations/2013_01_19_044505_create_comments_table.php
+++ b/app/database/migrations/2013_01_19_044505_create_comments_table.php
@@ -15,7 +15,7 @@ class CreateCommentsTable extends Migration {
 		Schema::create('comments', function($table)
 		{
 			$table->increments('id')->unsigned();
-			$table->integer('parent_id')->unsigned();
+			$table->integer('parent_id')->unsigned()->nullable();
 			$table->integer('post_id')->unsigned();
 			$table->integer('user_id')->unsigned();
 			$table->text('content');

--- a/app/database/migrations/2013_03_23_193214_update_users_table.php
+++ b/app/database/migrations/2013_03_23_193214_update_users_table.php
@@ -15,9 +15,9 @@ class UpdateUsersTable extends Migration {
 		Schema::table('users', function($table)
 		{
 			$table->softDeletes();
-			$table->string('website');
-			$table->string('country');
-			$table->string('gravatar');
+			$table->string('website')->nullable();
+			$table->string('country')->nullable();
+			$table->string('gravatar')->nullable();
 		});
 	}
 


### PR DESCRIPTION
Added nullable() to some add-on migrations to prevent 'has no default value' errors
